### PR TITLE
RINEX nav header parsing hardened

### DIFF
--- a/core/lib/FileHandling/RINEX/RinexNavHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexNavHeader.cpp
@@ -205,6 +205,7 @@ namespace gpstk
          }
          
          string thisLabel(line, 60, 20);
+         thisLabel = strip (thisLabel);
          
          if (thisLabel == versionString)
          {

--- a/core/lib/FileHandling/RINEX/RinexObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX/RinexObsHeader.cpp
@@ -519,6 +519,7 @@ namespace gpstk
       throw(FFStreamError)
    {
       string label(line, 60, 20);
+      label = strip(label);
 
       if (label == versionString)
       {

--- a/core/lib/FileHandling/RINEX3/Rinex3NavHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3NavHeader.cpp
@@ -187,6 +187,7 @@ namespace gpstk
          }
    
          string thisLabel(line, 60, 20);
+         thisLabel = strip(thisLabel);
 
             // following is huge if else else ... endif for each record type
          if(thisLabel == stringVersion) 

--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -968,6 +968,7 @@ namespace gpstk
    {
       int i;
       string label(line, 60, 20);
+      label = strip(label);
          
       if(label == hsVersion)
       {


### PR DESCRIPTION
Some BRDC sources provide 'weakly-formed' headers.
For example, ftp://ftp.glonass-iac.ru/MCC/BRDC/2017/BRDC0060.17n
(see PGM / RUN BY / DATE extra space symbol indentation).